### PR TITLE
Add flag to indicate doc data shouldn't be installed

### DIFF
--- a/mksnap-fedora-core
+++ b/mksnap-fedora-core
@@ -14,6 +14,7 @@ dnf \
 	--assumeyes \
 	--releasever=24 \
 	--setopt=install_weak_deps=False \
+	--setopt=tsflags=nodocs \
 	--installroot="$(pwd)/fedora-core-24" \
 	install \
 	passwd bash fedora-release filesystem glibc-minimal-langpack


### PR DESCRIPTION
Adds a flag to have DNF tell RPM to not install files labeled as documentation (`%doc`). This should further reduce the size of the generated core snap.
